### PR TITLE
Add neighbour methods to CLLocationCoordinate2D extension.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: swift
 osx_image: xcode10.2
 xcode_project: Geodesy.xcodeproj
 xcode_scheme: "Geodesy iOS"
-xcode_sdk: iphonesimulator11.0
+xcode_sdk: iphonesimulator12.2
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode9
+osx_image: xcode10.2
 xcode_project: Geodesy.xcodeproj
 xcode_scheme: "Geodesy iOS"
 xcode_sdk: iphonesimulator11.0

--- a/Source/Geodesy+CoreLocation.swift
+++ b/Source/Geodesy+CoreLocation.swift
@@ -32,6 +32,15 @@
         public func geohash(precision: Precision) -> String {
             return Region(coordinate: self, precision: precision.rawValue).hash
         }
+        
+        /// Geohash neighbors
+        public func neighbors(precision: Int = defaultPrecision) -> [String] {
+            return Region.init(coordinate: self, precision: precision).neighbors().map { $0.hash }
+        }
+        
+        public func neighbors(precision: Precision) -> [String] {
+            return neighbors(precision: precision.rawValue)
+        }
 
     }
 


### PR DESCRIPTION
Added neighbour methods to CLLocationCoordinate2D extension. Those methods are exactly the same as for CLLocation, I wonder why they were not added from the beginning. All test are green, works for my code at least.