### PR TITLE
Update podspec - use `version` in `source tag`

### DIFF
--- a/Geodesy.podspec
+++ b/Geodesy.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target 	= "10.10"
   s.watchos.deployment_target 	= "2.0"
   s.tvos.deployment_target 	= "9.0"
-  s.source       		= { :git => "https://github.com/proxpero/Geodesy.git", :tag => "1.2.0" }
+  s.source       		= { :git => "https://github.com/proxpero/Geodesy.git", :tag => s.version }
   s.source_files  		= "Source/*.swift"
 end


### PR DESCRIPTION
This is to avoid possible conflict upon updating the version for the pod.